### PR TITLE
Add utility helpers and Lua version conventions

### DIFF
--- a/rust/src/config.rs
+++ b/rust/src/config.rs
@@ -1,5 +1,6 @@
 use serde::Deserialize;
 use std::collections::HashMap;
+use crate::lua::LuaVersion;
 
 /// Prometheus global configuration constants.
 pub const NAME: &str = "Prometheus";
@@ -36,17 +37,6 @@ pub struct Step {
     pub settings: HashMap<String, serde_json::Value>,
 }
 
-#[derive(Debug, Clone, Deserialize)]
-pub enum LuaVersion {
-    Lua51,
-    LuaU,
-}
-
-impl Default for LuaVersion {
-    fn default() -> Self {
-        LuaVersion::Lua51
-    }
-}
 
 impl Default for Config {
     fn default() -> Self {

--- a/rust/src/lexer.rs
+++ b/rust/src/lexer.rs
@@ -1,5 +1,8 @@
 //! Tokenizer for Lua source code.
 
+use crate::lua::LuaVersion;
+use crate::util::{chararray, lookupify};
+
 /// Representation of a token in Lua.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum Token {
@@ -8,8 +11,11 @@ pub enum Token {
 }
 
 /// Convert Lua source code into a sequence of tokens.
-pub fn tokenize(_input: &str) -> Vec<Token> {
-    // Implementation will mirror the existing Lua tokenizer.
+pub fn tokenize(_input: &str, version: LuaVersion) -> Vec<Token> {
+    // Demonstrate usage of utility helpers for future implementation.
+    let chars = chararray(" \t");
+    let _lookup = lookupify(&chars);
+    let _conventions = version.conventions();
     unimplemented!("lexer not yet implemented");
 }
 

--- a/rust/src/lib.rs
+++ b/rust/src/lib.rs
@@ -7,9 +7,12 @@ pub mod obfuscator;
 pub mod config;
 pub mod colors;
 pub mod logger;
+pub mod util;
+pub mod lua;
 
 pub use obfuscator::obfuscate;
-pub use config::{Config, load_preset, LuaVersion};
+pub use config::{Config, load_preset};
+pub use lua::{LuaVersion, LuaConventions};
 pub use logger::{Logger, LogLevel};
 
 #[cfg(test)]

--- a/rust/src/lua.rs
+++ b/rust/src/lua.rs
@@ -1,0 +1,133 @@
+use serde::Deserialize;
+
+/// Supported Lua language versions.
+#[derive(Debug, Clone, Copy, Deserialize)]
+pub enum LuaVersion {
+    Lua51,
+    LuaU,
+}
+
+impl Default for LuaVersion {
+    fn default() -> Self {
+        LuaVersion::Lua51
+    }
+}
+
+/// Language conventions for a particular [`LuaVersion`].
+#[derive(Debug, Clone)]
+pub struct LuaConventions {
+    pub keywords: &'static [&'static str],
+    pub symbol_chars: &'static str,
+    pub max_symbol_length: usize,
+    pub symbols: &'static [&'static str],
+    pub ident_chars: &'static str,
+    pub number_chars: &'static str,
+    pub hex_number_chars: &'static str,
+    pub binary_number_chars: &'static [&'static str],
+    pub decimal_exponent: &'static [&'static str],
+    pub hexadecimal_nums: &'static [&'static str],
+    pub binary_nums: &'static [&'static str],
+    pub decimal_separators: Option<&'static [&'static str]>,
+    pub escape_sequences: &'static [(char, char)],
+    pub numerical_escapes: bool,
+    pub escape_z_ignore_next_whitespace: bool,
+    pub hex_escapes: bool,
+    pub unicode_escapes: bool,
+}
+
+impl LuaVersion {
+    /// Get the conventions associated with this Lua version.
+    pub fn conventions(&self) -> &'static LuaConventions {
+        match self {
+            LuaVersion::Lua51 => &LUA51_CONVENTIONS,
+            LuaVersion::LuaU => &LUAU_CONVENTIONS,
+        }
+    }
+}
+
+/// Conventions for Lua 5.1.
+pub static LUA51_CONVENTIONS: LuaConventions = LuaConventions {
+    keywords: &[
+        "and", "break", "do", "else", "elseif",
+        "end", "false", "for", "function", "if",
+        "in", "local", "nil", "not", "or",
+        "repeat", "return", "then", "true", "until", "while",
+    ],
+    symbol_chars: "+-*/%^#=~<>(){}[];:,.",
+    max_symbol_length: 3,
+    symbols: &[
+        "+", "-", "*", "/", "%", "^", "#",
+        "==", "~=", "<=", ">=", "<", ">", "=",
+        "(", ")", "{", "}", "[", "]",
+        ";", ":", ",", ".", "..", "...",
+    ],
+    ident_chars: "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ_0123456789",
+    number_chars: "0123456789",
+    hex_number_chars: "0123456789abcdefABCDEF",
+    binary_number_chars: &["0", "1"],
+    decimal_exponent: &["e", "E"],
+    hexadecimal_nums: &["x", "X"],
+    binary_nums: &["b", "B"],
+    decimal_separators: None,
+    escape_sequences: &[
+        ('a', '\u{07}'),
+        ('b', '\u{08}'),
+        ('f', '\u{0C}'),
+        ('n', '\n'),
+        ('r', '\r'),
+        ('t', '\t'),
+        ('v', '\u{0B}'),
+        ('\\', '\\'),
+        ('"', '"'),
+        ('\'', '\'')
+    ],
+    numerical_escapes: true,
+    escape_z_ignore_next_whitespace: true,
+    hex_escapes: true,
+    unicode_escapes: true,
+};
+
+/// Conventions for the LuaU dialect.
+pub static LUAU_CONVENTIONS: LuaConventions = LuaConventions {
+    keywords: &[
+        "and", "break", "do", "else", "elseif", "continue",
+        "end", "false", "for", "function", "if",
+        "in", "local", "nil", "not", "or",
+        "repeat", "return", "then", "true", "until", "while",
+    ],
+    symbol_chars: "+-*/%^#=~<>(){}[];:,.",
+    max_symbol_length: 3,
+    symbols: &[
+        "+", "-", "*", "/", "%", "^", "#",
+        "==", "~=", "<=", ">=", "<", ">", "=",
+        "+=", "-=", "/=", "%=", "^=", "..=", "*=",
+        "(", ")", "{", "}", "[", "]",
+        ";", ":", ",", ".", "..", "...",
+        "::", "->", "?", "|", "&",
+    ],
+    ident_chars: "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ_0123456789",
+    number_chars: "0123456789",
+    hex_number_chars: "0123456789abcdefABCDEF",
+    binary_number_chars: &["0", "1"],
+    decimal_exponent: &["e", "E"],
+    hexadecimal_nums: &["x", "X"],
+    binary_nums: &["b", "B"],
+    decimal_separators: Some(&["_"]),
+    escape_sequences: &[
+        ('a', '\u{07}'),
+        ('b', '\u{08}'),
+        ('f', '\u{0C}'),
+        ('n', '\n'),
+        ('r', '\r'),
+        ('t', '\t'),
+        ('v', '\u{0B}'),
+        ('\\', '\\'),
+        ('"', '"'),
+        ('\'', '\'')
+    ],
+    numerical_escapes: true,
+    escape_z_ignore_next_whitespace: true,
+    hex_escapes: true,
+    unicode_escapes: true,
+};
+

--- a/rust/src/obfuscator.rs
+++ b/rust/src/obfuscator.rs
@@ -2,11 +2,13 @@
 
 use crate::lexer::tokenize;
 use crate::parser::parse;
+use crate::lua::LuaVersion;
 
 /// Obfuscate the provided Lua source code.
 pub fn obfuscate(source: &str) -> String {
-    let tokens = tokenize(source);
-    let _ast = parse(&tokens);
+    let version = LuaVersion::Lua51;
+    let tokens = tokenize(source, version);
+    let _ast = parse(&tokens, version);
 
     // Future work: apply transformation pipeline and generate obfuscated code.
     unimplemented!("obfuscation pipeline not yet implemented");

--- a/rust/src/parser.rs
+++ b/rust/src/parser.rs
@@ -2,9 +2,13 @@
 
 use crate::ast::AstNode;
 use crate::lexer::Token;
+use crate::lua::LuaVersion;
+use crate::util::escape;
 
 /// Parse a slice of tokens into an AST.
-pub fn parse(_tokens: &[Token]) -> AstNode {
+pub fn parse(_tokens: &[Token], version: LuaVersion) -> AstNode {
+    let _ = version.conventions();
+    let _ = escape("test");
     // Implementation will mirror the existing Lua parser.
     unimplemented!("parser not yet implemented");
 }

--- a/rust/src/util.rs
+++ b/rust/src/util.rs
@@ -1,0 +1,71 @@
+use std::collections::{HashSet};
+use std::hash::Hash;
+
+/// Convert a slice into a [`HashSet`] for fast lookup.
+pub fn lookupify<T>(items: &[T]) -> HashSet<T>
+where
+    T: Eq + Hash + Clone,
+{
+    items.iter().cloned().collect()
+}
+
+/// Convert a [`HashSet`] back into a [`Vec`].
+pub fn unlookupify<T>(set: &HashSet<T>) -> Vec<T>
+where
+    T: Eq + Hash + Clone,
+{
+    set.iter().cloned().collect()
+}
+
+/// Escape a string using Lua style escape sequences.
+pub fn escape(input: &str) -> String {
+    input
+        .chars()
+        .map(|c| match c {
+            '\\' => "\\\\".to_string(),
+            '\n' => "\\n".to_string(),
+            '\r' => "\\r".to_string(),
+            '\t' => "\\t".to_string(),
+            '\u{07}' => "\\a".to_string(),
+            '\u{08}' => "\\b".to_string(),
+            '\u{0B}' => "\\v".to_string(),
+            '\"' => "\\\"".to_string(),
+            '\'' => "\\'".to_string(),
+            c if !c.is_ascii() || (c.is_control() && c != '\n' && c != '\t') => {
+                format!("\\{:03}", c as u8)
+            }
+            c => c.to_string(),
+        })
+        .collect()
+}
+
+/// Split a string into a vector of characters.
+pub fn chararray(input: &str) -> Vec<char> {
+    input.chars().collect()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn lookup_roundtrip() {
+        let data = ["a", "b"]; // slice of &str
+        let set = lookupify(&data);
+        let vec = unlookupify(&set);
+        assert_eq!(set.len(), 2);
+        assert!(vec.contains(&"a"));
+        assert!(vec.contains(&"b"));
+    }
+
+    #[test]
+    fn escape_basic() {
+        assert_eq!(escape("a\n"), "a\\n");
+    }
+
+    #[test]
+    fn chararray_basic() {
+        assert_eq!(chararray("ab"), vec!['a', 'b']);
+    }
+}
+


### PR DESCRIPTION
## Summary
- add lookupify, escape, and chararray helpers in a new util module
- model LuaVersion and language conventions in Rust
- wire tokenizer and parser stubs to use shared utilities

## Testing
- `cargo test`

------
https://chatgpt.com/codex/tasks/task_b_68c5d5363014832f93904dcd840a76df