### PR TITLE
Add Rust name generators and random helper modules

### DIFF
--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -53,6 +53,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "cfg-if"
+version = "1.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2fd1289c04a9ea8cb22300a459a72a385d7c73d3259e2ed7dcb2af674838cfa9"
+
+[[package]]
 name = "clap"
 version = "4.5.47"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -99,6 +105,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b05b61dc5112cbb17e4b6cd61790d9845d13888356391624cbe7e41efeac1e75"
 
 [[package]]
+name = "getrandom"
+version = "0.2.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "335ff9f135e4384c8150d6f27c6daed433577f86b4750418338c01a1a2528592"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "wasi",
+]
+
+[[package]]
 name = "heck"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -115,6 +132,12 @@ name = "itoa"
 version = "1.0.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4a5f13b858c8d314ee3e8f639011f7ccefe71f97f96e50151fb991f267928e2c"
+
+[[package]]
+name = "libc"
+version = "0.2.175"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6a82ae493e598baaea5209805c49bbf2ea7de956d50d7da0da1164f9c6d28543"
 
 [[package]]
 name = "memchr"
@@ -145,6 +168,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a4895175b425cb1f87721b59f0f286c2092bd4af812243672510e1ac53e2e0ad"
 
 [[package]]
+name = "ppv-lite86"
+version = "0.2.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85eae3c4ed2f50dcfe72643da4befc30deadb458a9b590d720cde2f2b1e97da9"
+dependencies = [
+ "zerocopy",
+]
+
+[[package]]
 name = "proc-macro2"
 version = "1.0.101"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -159,6 +191,7 @@ version = "0.1.0"
 dependencies = [
  "clap",
  "nom",
+ "rand",
  "serde",
  "serde_json",
 ]
@@ -170,6 +203,36 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1885c039570dc00dcb4ff087a89e185fd56bae234ddc7f056a945bf36467248d"
 dependencies = [
  "proc-macro2",
+]
+
+[[package]]
+name = "rand"
+version = "0.8.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "34af8d1a0e25924bc5b7c43c079c942339d8f0a8b57c39049bef581b46327404"
+dependencies = [
+ "libc",
+ "rand_chacha",
+ "rand_core",
+]
+
+[[package]]
+name = "rand_chacha"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e6c10a63a0fa32252be49d21e7709d4d4baf8d231c2dbce1eaa8141b9b127d88"
+dependencies = [
+ "ppv-lite86",
+ "rand_core",
+]
+
+[[package]]
+name = "rand_core"
+version = "0.6.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
+dependencies = [
+ "getrandom",
 ]
 
 [[package]]
@@ -238,6 +301,12 @@ name = "utf8parse"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
+
+[[package]]
+name = "wasi"
+version = "0.11.1+wasi-snapshot-preview1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ccf3ec651a847eb01de73ccad15eb7d99f80485de043efb2f370cd654f4ea44b"
 
 [[package]]
 name = "windows-link"
@@ -318,3 +387,23 @@ name = "windows_x86_64_msvc"
 version = "0.53.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "271414315aff87387382ec3d271b52d7ae78726f5d44ac98b4f4030c91880486"
+
+[[package]]
+name = "zerocopy"
+version = "0.8.27"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0894878a5fa3edfd6da3f88c4805f4c8558e2b996227a3d864f47fe11e38282c"
+dependencies = [
+ "zerocopy-derive",
+]
+
+[[package]]
+name = "zerocopy-derive"
+version = "0.8.27"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "88d2b8d9c68ad2b9e4340d7832716a4d21a22a1154777ad56ea55c51a9cf3831"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -10,3 +10,4 @@ nom = "7"
 clap = { version = "4", features = ["derive"] }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
+rand = "0.8"

--- a/rust/src/lib.rs
+++ b/rust/src/lib.rs
@@ -6,12 +6,15 @@ pub mod config;
 pub mod lexer;
 pub mod logger;
 pub mod lua;
+pub mod name_generators;
 pub mod obfuscator;
 pub mod parser;
 pub mod pipeline;
+pub mod random_literals;
+pub mod random_strings;
 pub mod util;
 
-pub use config::{load_preset, Config};
+pub use config::{Config, load_preset};
 pub use logger::{LogLevel, Logger};
 pub use lua::{LuaConventions, LuaVersion};
 pub use obfuscator::obfuscate;

--- a/rust/src/name_generators.rs
+++ b/rust/src/name_generators.rs
@@ -1,0 +1,334 @@
+use rand::rngs::StdRng;
+use rand::{Rng, SeedableRng, seq::SliceRandom};
+
+use crate::pipeline::NameGenerator;
+
+const MANGLED_VAR_DIGITS: &[u8] =
+    b"abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789_";
+const MANGLED_VAR_START: &[u8] = b"abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ";
+
+/// Generates simple increasing identifiers in the form `_1`, `_2`, …
+pub struct NumberGenerator {
+    counter: u64,
+}
+
+impl NumberGenerator {
+    pub fn new() -> Self {
+        Self { counter: 0 }
+    }
+}
+
+impl NameGenerator for NumberGenerator {
+    fn generate(&mut self) -> String {
+        self.counter += 1;
+        format!("_{}", self.counter)
+    }
+}
+
+/// Mimics the `mangled.lua` name generator from the Lua implementation.
+pub struct MangledGenerator {
+    counter: u64,
+}
+
+impl MangledGenerator {
+    pub fn new() -> Self {
+        Self { counter: 0 }
+    }
+}
+
+impl NameGenerator for MangledGenerator {
+    fn generate(&mut self) -> String {
+        self.counter += 1;
+        let mut id = self.counter;
+        let base_start = MANGLED_VAR_START.len() as u64;
+        let base_digits = MANGLED_VAR_DIGITS.len() as u64;
+
+        let mut name = String::new();
+        let d = (id % base_start) as usize;
+        id = (id - d as u64) / base_start;
+        name.push(MANGLED_VAR_START[d] as char);
+
+        while id > 0 {
+            let d = (id % base_digits) as usize;
+            id = (id - d as u64) / base_digits;
+            name.push(MANGLED_VAR_DIGITS[d] as char);
+        }
+
+        name
+    }
+}
+
+/// Equivalent to `mangled_shuffled.lua` where the character order is randomised.
+pub struct MangledShuffledGenerator {
+    counter: u64,
+    var_digits: Vec<u8>,
+    var_start_digits: Vec<u8>,
+}
+
+impl MangledShuffledGenerator {
+    pub fn new(seed: u64) -> Self {
+        let mut var_digits = MANGLED_VAR_DIGITS.to_vec();
+        let mut var_start_digits = MANGLED_VAR_START.to_vec();
+        let mut rng = StdRng::seed_from_u64(seed);
+        var_digits.shuffle(&mut rng);
+        var_start_digits.shuffle(&mut rng);
+        Self {
+            counter: 0,
+            var_digits,
+            var_start_digits,
+        }
+    }
+}
+
+impl NameGenerator for MangledShuffledGenerator {
+    fn generate(&mut self) -> String {
+        self.counter += 1;
+        let mut id = self.counter;
+        let base_start = self.var_start_digits.len() as u64;
+        let base_digits = self.var_digits.len() as u64;
+
+        let mut name = String::new();
+        let d = (id % base_start) as usize;
+        id = (id - d as u64) / base_start;
+        name.push(self.var_start_digits[d] as char);
+
+        while id > 0 {
+            let d = (id % base_digits) as usize;
+            id = (id - d as u64) / base_digits;
+            name.push(self.var_digits[d] as char);
+        }
+
+        name
+    }
+}
+
+const IL_VAR_DIGITS: &[u8] = b"Il1";
+const IL_VAR_START: &[u8] = b"Il";
+const MIN_CHARACTERS: u32 = 5;
+const MAX_INITIAL_CHARACTERS: u32 = 10;
+
+/// Generator producing confusing names consisting only of `I`, `l` and `1`.
+pub struct IlGenerator {
+    counter: u64,
+    offset: u64,
+    var_digits: Vec<u8>,
+    var_start_digits: Vec<u8>,
+}
+
+impl IlGenerator {
+    pub fn new(seed: u64) -> Self {
+        let mut var_digits = IL_VAR_DIGITS.to_vec();
+        let mut var_start_digits = IL_VAR_START.to_vec();
+        let mut rng = StdRng::seed_from_u64(seed);
+        var_digits.shuffle(&mut rng);
+        var_start_digits.shuffle(&mut rng);
+        let min = 3u64.pow(MIN_CHARACTERS);
+        let max = 3u64.pow(MAX_INITIAL_CHARACTERS);
+        let offset = rng.gen_range(min..=max);
+        Self {
+            counter: 0,
+            offset,
+            var_digits,
+            var_start_digits,
+        }
+    }
+}
+
+impl NameGenerator for IlGenerator {
+    fn generate(&mut self) -> String {
+        self.counter += 1;
+        let mut id = self.counter + self.offset;
+        let base_start = self.var_start_digits.len() as u64;
+        let base_digits = self.var_digits.len() as u64;
+
+        let mut name = String::new();
+        let d = (id % base_start) as usize;
+        id = (id - d as u64) / base_start;
+        name.push(self.var_start_digits[d] as char);
+
+        while id > 0 {
+            let d = (id % base_digits) as usize;
+            id = (id - d as u64) / base_digits;
+            name.push(self.var_digits[d] as char);
+        }
+
+        name
+    }
+}
+
+/// Generator that assembles identifiers from shuffled common variable names.
+pub struct ConfuseGenerator {
+    counter: u64,
+    names: Vec<&'static str>,
+}
+
+impl ConfuseGenerator {
+    pub fn new(seed: u64) -> Self {
+        let mut names = VAR_NAMES.to_vec();
+        let mut rng = StdRng::seed_from_u64(seed);
+        names.shuffle(&mut rng);
+        Self { counter: 0, names }
+    }
+}
+
+impl NameGenerator for ConfuseGenerator {
+    fn generate(&mut self) -> String {
+        self.counter += 1;
+        let mut id = self.counter;
+        let base = self.names.len() as u64;
+        let mut parts: Vec<&'static str> = Vec::new();
+        let d = (id % base) as usize;
+        id = (id - d as u64) / base;
+        parts.push(self.names[d]);
+        while id > 0 {
+            let d = (id % base) as usize;
+            id = (id - d as u64) / base;
+            parts.push(self.names[d]);
+        }
+        parts.join("_")
+    }
+}
+
+const VAR_NAMES: [&str; 141] = [
+    "index",
+    "iterator",
+    "length",
+    "size",
+    "key",
+    "value",
+    "data",
+    "count",
+    "increment",
+    "include",
+    "string",
+    "number",
+    "type",
+    "void",
+    "int",
+    "float",
+    "bool",
+    "char",
+    "double",
+    "long",
+    "short",
+    "unsigned",
+    "signed",
+    "program",
+    "factory",
+    "Factory",
+    "new",
+    "delete",
+    "table",
+    "array",
+    "object",
+    "class",
+    "arr",
+    "obj",
+    "cls",
+    "dir",
+    "directory",
+    "isWindows",
+    "isLinux",
+    "game",
+    "roblox",
+    "gmod",
+    "gsub",
+    "gmatch",
+    "gfind",
+    "onload",
+    "load",
+    "loadstring",
+    "loadfile",
+    "dofile",
+    "require",
+    "parse",
+    "byte",
+    "code",
+    "bytecode",
+    "idx",
+    "const",
+    "loader",
+    "loaders",
+    "module",
+    "export",
+    "exports",
+    "import",
+    "imports",
+    "package",
+    "packages",
+    "_G",
+    "math",
+    "os",
+    "io",
+    "write",
+    "print",
+    "read",
+    "readline",
+    "readlines",
+    "close",
+    "flush",
+    "open",
+    "popen",
+    "tmpfile",
+    "tmpname",
+    "rename",
+    "remove",
+    "seek",
+    "setvbuf",
+    "lines",
+    "call",
+    "apply",
+    "raise",
+    "pcall",
+    "xpcall",
+    "coroutine",
+    "create",
+    "resume",
+    "status",
+    "wrap",
+    "yield",
+    "debug",
+    "traceback",
+    "getinfo",
+    "getlocal",
+    "setlocal",
+    "getupvalue",
+    "setupvalue",
+    "getuservalue",
+    "setuservalue",
+    "upvalueid",
+    "upvaluejoin",
+    "sethook",
+    "gethook",
+    "hookfunction",
+    "hooks",
+    "error",
+    "setmetatable",
+    "getmetatable",
+    "rand",
+    "randomseed",
+    "next",
+    "ipairs",
+    "hasnext",
+    "loadlib",
+    "searchpath",
+    "oldpath",
+    "newpath",
+    "path",
+    "rawequal",
+    "rawset",
+    "rawget",
+    "rawnew",
+    "rawlen",
+    "select",
+    "tonumber",
+    "tostring",
+    "assert",
+    "collectgarbage",
+    "a",
+    "b",
+    "c",
+    "i",
+    "j",
+    "m",
+];

--- a/rust/src/random_literals.rs
+++ b/rust/src/random_literals.rs
@@ -1,0 +1,32 @@
+use rand::Rng;
+
+use crate::ast::Expression;
+use crate::pipeline::Pipeline;
+
+use crate::random_strings;
+
+/// Create a random string literal using the pipeline's name generator.
+pub fn string_literal(pipeline: &mut Pipeline) -> Expression {
+    Expression::String(pipeline.name_generator.generate())
+}
+
+/// Create a random dictionary key represented as a string expression.
+pub fn dictionary_literal() -> Expression {
+    random_strings::random_string_expr(None)
+}
+
+/// Create a random number literal in the range used by the Lua codebase.
+pub fn number_literal() -> Expression {
+    let mut rng = rand::thread_rng();
+    Expression::Number(rng.gen_range(-8_388_608..=8_388_607) as f64)
+}
+
+/// Return a random literal of any of the supported types.
+pub fn any_literal(pipeline: &mut Pipeline) -> Expression {
+    let mut rng = rand::thread_rng();
+    match rng.gen_range(1..=3) {
+        1 => string_literal(pipeline),
+        2 => number_literal(),
+        _ => dictionary_literal(),
+    }
+}

--- a/rust/src/random_strings.rs
+++ b/rust/src/random_strings.rs
@@ -1,0 +1,26 @@
+use rand::Rng;
+use rand::seq::SliceRandom;
+
+use crate::ast::Expression;
+
+const CHARSET: &[u8] = b"qwertyuiopasdfghjklzxcvbnmQWERTYUIOPASDFGHJKLZXCVBNM1234567890";
+
+/// Generate a random string. If `words` is provided a random element from the
+/// list is returned, otherwise a string of random characters with a random
+/// length between 2 and 15 is produced.
+pub fn random_string(words: Option<&[&str]>) -> String {
+    let mut rng = rand::thread_rng();
+    if let Some(words) = words {
+        words.choose(&mut rng).unwrap().to_string()
+    } else {
+        let len = rng.gen_range(2..=15);
+        (0..len)
+            .map(|_| *CHARSET.choose(&mut rng).unwrap() as char)
+            .collect()
+    }
+}
+
+/// Convenience wrapper returning the string as an [`Expression`].
+pub fn random_string_expr(words: Option<&[&str]>) -> Expression {
+    Expression::String(random_string(words))
+}


### PR DESCRIPTION
## Summary
- port Lua name generators (mangled, shuffled, Il, confuse, number) to Rust trait implementations
- add random string and literal helpers using `rand`
- allow selecting generators in the pipeline

## Testing
- `cargo fmt --manifest-path rust/Cargo.toml -- rust/src/lib.rs rust/src/pipeline.rs rust/src/name_generators.rs rust/src/random_literals.rs rust/src/random_strings.rs`
- `cargo test`

------
https://chatgpt.com/codex/tasks/task_b_68c5f3eeb638832f9a3c408be7fd83ac